### PR TITLE
Changes content-type from text/xml to application/xml

### DIFF
--- a/Classes/Generator/AbstractSitemapGenerator.php
+++ b/Classes/Generator/AbstractSitemapGenerator.php
@@ -91,7 +91,7 @@ abstract class AbstractSitemapGenerator {
 	 * @return void
 	 */
 	public function main() {
-		header('Content-type: text/xml');
+		header('Content-type: application/xml');
 		if ($this->renderer) {
 			echo $this->renderer->getStartTags();
 		}


### PR DESCRIPTION
Google search console says that it is unable to read the sitemap if the content-type is not application/xml.